### PR TITLE
Update launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "clr",
             "request": "launch",
             "preLaunchTask": "build dll",
-            "args": [],
+            "args": ["-quicktest"],
             "program": "../../RimWorldWin64.exe",
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",


### PR DESCRIPTION
Add the `quicktest` command argument, which instantly launches the game into a map, so that developers don't need to create a new map every time.